### PR TITLE
Feat/rag hand ingest retrieval

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -1,5 +1,9 @@
 import json
 from pathlib import Path
+import os
+import sys
+from workflows import run_workflow_from_new_hand
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from utils.io_helpers import load_data, save_data
 from utils.format import format_hand_for_llm
 from llm.prompts import generate_coaching_feedback
@@ -56,12 +60,14 @@ def main():
     print("Welcome to the Poker Coach CLI")
     while True:
         print("\nOptions:")
-        print("1. View Sample Hand")
-        print("2. Input New Hand Data")
+        print("1. Input New Hand Data")
+        print("2. View Previous Hand")
         print("3. Exit")
 
         choice = input("\nChoose an option (1-3): ")
         if choice == '1':
+            run_workflow_from_new_hand()
+        elif choice == '2':
             try:
                 hand = load_data(DATA_PATH)
                 formatted_hand = format_hand_for_llm(hand)
@@ -77,8 +83,6 @@ def main():
                 print("Sample hand data not found. Please ensure the file exists.")
             except json.JSONDecodeError:
                 print("Error decoding the sample hand data. Please check the file format.")
-        elif choice == '2':
-            print("This feature is not yet implemented. Please check back later.")
         elif choice == '3':
             print("Exiting the Poker Coach CLI. Goodbye!")
             break

--- a/cli/workflows.py
+++ b/cli/workflows.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Dict
+import sys
+import os
+import weaviate
+from weaviate.classes.query import MetadataQuery
+from dotenv import load_dotenv
+load_dotenv(dotenv_path=Path(__file__).resolve().parents[1] / ".env")
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from utils.hand_input import collect_hand_config
+from utils.preflop_input import collect_preflop, PreflopRecord
+from utils.flop_input import collect_flop
+from utils.turn_input import collect_turn
+from utils.river_input import collect_river
+from utils.game_flow import POS_9MAX
+from langchain_openai import ChatOpenAI
+from utils.rag_pipeline import (
+    build_final_rag_schema,
+    enrich_user_hand_with_llm,
+    search_weaviate_hybrid,
+    build_nl_summary,
+)
+#from test_fixtures import serialize_hand_fixture, save_fixture
+from weaviate.classes.init import Auth
+from utils.embedding import embed
+from utils.coaching import generate_coaching_advice, build_evidence_context, evidence_card_from_obj
+
+# ---------------------------
+# Glue: who reached the flop?
+# ---------------------------
+def participants_to_flop(pre: PreflopRecord) -> List[str]:
+    """
+    Seats whose FINAL preflop state is call/raise (not fold).
+    Return in table order.
+    """
+    final = {pre.opener: "raise"}
+    for a in pre.trail_actions:
+        final[a.position] = a.action
+    involved = [p for p, act in final.items() if act in ("call", "raise")]
+    return [p for p in POS_9MAX if p in involved]
+
+# ---------------------------
+# Flop board feature extractor (lightweight, RAG-friendly)
+# ---------------------------
+_RANK_VAL = {r: i for i, r in enumerate("..23456789TJQKA", start=0)}  # quick map
+
+def analyze_flop(board: str) -> Dict[str, object]:
+    """
+    board: "AsTd2d"
+    Returns very compact features for retrieval/reranking.
+    """
+    cards = [board[i:i+2] for i in range(0, len(board), 2)]
+    ranks = [c[0] for c in cards]
+    suits = [c[1] for c in cards]
+
+    suit_counts = {s: suits.count(s) for s in set(suits)}
+    flush_level = max(suit_counts.values())  # 1..3
+
+    rank_counts = {r: ranks.count(r) for r in set(ranks)}
+    paired_level = max(rank_counts.values()) if rank_counts else 0
+    paired_level = 0 if paired_level == 1 else paired_level
+
+    vals = sorted({_RANK_VAL[r] for r in ranks})
+    vals_wheel = {14 if v != 14 else 1 for v in vals}
+    span = max(vals) - min(vals)
+    span_wheel = max(vals_wheel) - min(vals_wheel)
+    if len(vals) == 3 and (span <= 2 or span_wheel <= 2):
+        straightness = 2
+    elif len(vals) == 3 and (span <= 4 or span_wheel <= 4):
+        straightness = 1
+    else:
+        straightness = 0
+
+    hi = max(vals)
+    high_card_bucket = "H" if hi >= _RANK_VAL["Q"] else ("M" if hi >= _RANK_VAL["9"] else "L")
+
+    if flush_level == 3:
+        texture_class = "monotone"
+    elif paired_level >= 2:
+        texture_class = "paired"
+    elif straightness >= 1:
+        texture_class = "draw-heavy"
+    else:
+        texture_class = "dry"
+
+    return {
+        "flop_board": board,
+        "flush_level": flush_level,          # 1..3
+        "paired_level": 0 if paired_level == 0 else (1 if paired_level == 2 else 3),
+        "straightness": straightness,        # 0 low / 1 some / 2 strong
+        "high_card_bucket": high_card_bucket,# H/M/L
+        "texture_class": texture_class,      # dry/paired/monotone/draw-heavy
+    }
+
+# ---------------------------
+# Build a compact RAG schema
+# ---------------------------
+def build_rag_schema(cfg, pre: PreflopRecord, flop_rec, flop_feats: Dict[str, object]) -> Dict[str, object]:
+    pre_tokens = pre.preflop_tokens
+    flop_tokens = flop_rec.tokens
+    line_compact = f"{pre_tokens} || {flop_tokens}"
+
+    schema_string = f"{cfg.schema_tokens()} | preflop={pre_tokens} | flop={flop_tokens}"
+
+    facets = {
+        "pot_type": pre.pot_type,
+        "players_to_flop": pre.players_to_flop,
+        "positions": participants_to_flop(pre),
+        "line_compact": line_compact,
+        **flop_feats,
+    }
+
+    embedding_text = (
+        f"{cfg.schema_tokens()}. Preflop: {pre_tokens}. "
+        f"Flop: {flop_tokens}. Board is {flop_feats['texture_class']} "
+        f"(flush_level={flop_feats['flush_level']}, paired_level={flop_feats['paired_level']}, "
+        f"straightness={flop_feats['straightness']}, high={flop_feats['high_card_bucket']})."
+    )
+
+    return {
+        "title": "User-entered hand (preflop+flop)",
+        "schema_string": schema_string,
+        "embedding_text": embedding_text,
+        "facets": facets,
+        "tokens": {
+            "preflop": pre_tokens,
+            "flop": flop_tokens,
+        },
+    }
+
+# ---------------------------
+# CLI runner
+# ---------------------------
+
+def run_workflow_from_new_hand():
+    print("\n=== Hand Config ===")
+    cfg = collect_hand_config()
+
+    print("\n=== Preflop ===")
+    pre = collect_preflop(cfg)
+
+    if pre.players_to_flop <= 1:
+        print("\nHand ended preflop (no flop).")
+
+    parts = participants_to_flop(pre)
+    print("\n=== Flop ===")
+    flop_result = collect_flop(parts)
+    flop_rec = flop_result.record
+    flop_feats = analyze_flop(flop_rec.board)
+    turn_result = None
+    river_result = None
+    if len(flop_result.remaining_positions) > 1:
+        print("\n=== Turn ===")
+        turn_result = collect_turn(flop_result.remaining_positions)
+        print(turn_result.record.pretty())
+        tokens_turn = turn_result.record.tokens
+
+    if len(turn_result.remaining_positions) > 1:
+        print("\n=== River ===")
+        river_result = collect_river(turn_result.remaining_positions)
+        print(river_result.record.pretty())
+        if river_result.showdown_raw:
+            print("Showdown:", river_result.showdown_raw)
+
+    raw_query = build_final_rag_schema(
+        cfg=cfg,
+        pre=pre,
+        flop_rec=flop_result.record if flop_result else None,
+        flop_feats=flop_feats,
+        turn_rec=turn_result.record if turn_result else None,
+        river_rec=river_result.record if river_result else None,
+        showdown_raw=getattr(river_result, "showdown_raw", None) if river_result else None,
+    )
+
+    llm = ChatOpenAI(model="gpt-5-mini")
+    enriched_query = enrich_user_hand_with_llm(llm, raw_query, cfg)
+
+    nl_summary  = build_nl_summary(
+        cfg=cfg,
+        pre=pre,
+        flop_rec=flop_result.record if flop_result else None,
+        turn_rec=turn_result.record if turn_result else None,
+        river_rec=river_result.record if river_result else None
+    )
+
+    # fixture = serialize_hand_fixture(
+    #     cfg=cfg,
+    #     pre=pre,
+    #     flop_result=flop_result,
+    #     turn_result=turn_result,
+    #     river_result=river_result,
+    #     nl_summary=nl_summary,
+    #     raw_query=raw_query,
+    # )
+    # save_fixture(fixture) 
+
+    headers = {"X-OpenAI-Api-Key": os.getenv("OPENAI_API_KEY")}
+
+    client = weaviate.connect_to_weaviate_cloud(
+        cluster_url=os.getenv("WEAVIATE_URL"),
+        auth_credentials=weaviate.auth.AuthApiKey(os.getenv("WEAVIATE_API_KEY")),
+        headers=headers,
+        skip_init_checks=True,
+    )
+    print("\n\nconnected to client?: ", client.is_connected())
+
+    #3) Weaviate hybrid search (BM25 + dense) with safe hard_filters
+    objects, debug = search_weaviate_hybrid(
+        client=client,                   # your weaviate client
+        collection_name="PokerHand",
+        enriched_query_doc=enriched_query,
+        top_k=3,
+        alpha=0.5,
+        embed_fn=embed
+    )
+
+    evidence_context, evidence_json = build_evidence_context(objects, k=3)
+    advice = generate_coaching_advice(nl_summary, evidence_context, evidence_json, model="gpt-5-mini")
+    
+    print("\n=== Coaching Advice ===\n")
+    print(advice)
+
+
+    
+    client.close()
+
+def main() -> None:
+    print("nun")
+    
+
+def _emit(payload: dict, filename: str) -> None:
+    print("\n--- RAG Schema (preflop+flop) ---")
+    print(json.dumps(payload, indent=2))
+    out = Path.cwd() / filename
+    out.write_text(json.dumps(payload, indent=2))
+    print(f"\nSaved to {out}")

--- a/utils/coaching.py
+++ b/utils/coaching.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import json
+from typing import List, Dict, Any, Optional
+
+
+from dotenv import load_dotenv
+from pathlib import Path
+import sys
+import os
+load_dotenv(dotenv_path=Path(__file__).resolve().parents[1] / ".env")
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from langchain_openai import ChatOpenAI
+
+# ---------------------------
+# System prompt for coaching
+# ---------------------------
+SYSTEM_PROMPT = (
+    """
+    You are a professional poker coach with 10+ years of live cash experience. Your job is to turn a single hand history into concise, actionable, street-by-street coaching a player can use to fix leaks and to improve their poker gameplay.
+    Coaching stance:
+    Prefer exploitative adjustments when pool reads suggest an edge (over-calling, under-bluffing, sizing tells).
+    Otherwise anchor to a GTO-consistent baseline and explain why.
+    Avoid results-oriented bias: evaluate decisions with the info available at the time.
+    Cards & data:
+    You may and should reference exact hole cards and board cards (ranks/suits) where relevant.
+    Be numerically consistent with stacks, SPR, and pot sizes; if math matters, show the one-line calculation (e.g., “need 28% equity to call”).
+    Spot definition & similarity (for retrieved coaching):
+    A “spot” = formation (pot type, HU/MW, IP/OOP) + street + board state (texture class + notable runout event) + SPR bucket + line semantics (c-bet / probe / check-raise / barrel / overbet / jam).
+    SIMILAR (use as primary evidence) when all hold:
+    Street matches (river > turn > flop).
+    Formation compatible (same pot type or same IP/OOP; HU vs MW should match unless advice is clearly formation-agnostic).
+    Board state compatible (same/adjacent texture; for turn/river the same runout event such as turn completes flush or river pairs board).
+    SPR close (same bucket or adjacent: SPR<1, ~2, ~3–5, >5).
+    Line overlap (≥1 shared action token: c-bet, check-raise, probe, barrel, overbet, jam).
+    If data is sparse, keep (1)+(2) and require at least one of {(3),(4),(5)}.
+
+
+    NOT SIMILAR (discard) if any: street mismatch that the tip hinges on; formation conflict that changes incentives (e.g., limped vs 4-bet, HU vs 4-way) and advice is formation-sensitive; board/runout contradiction (e.g., monotone-specific guidance on rainbow/paired dry); SPR far off so commitment thresholds flip; or line/node mismatch (e.g., tip about facing a check-raise applied to bet-bet-jam).
+    Tie-breakers (borderline cases): prioritize alignment on line semantics and runout event, then formation, then SPR, then texture; use coarse hand class (pair/draw/air/monster) only as a final tiebreaker.
+    Evidence policy (precedence)
+    You MUST integrate retrieved coaching when it is similar enough to the spot and let it guide your advice.
+    Merge the 2–4 strongest ideas; if conflicts arise, prefer the retrieved guidance unless it is clearly inapplicable due to explicit hand details.
+    Output style
+    Be crisp and imperative; no narration of every action. Reference the canonical line_compact once if needed.
+    Use sizing bands only when helpful (e.g., 25–33%, 60–75%, 110–150%).
+    When multiple viable lines exist, present a default line + a brief exploitative deviation and when to use it.`
+    Vocabulary (use consistently)
+    SPR, range advantage, nut advantage, capped range, polarity, blockers, bluff-catcher, thin value, deny equity, realization, MDF, pot odds.
+    Deliverable
+    Produce a street-by-street breakdown with short bullets for what to do and why, optional sizes, and citations only if evidence was used. End with 1–2 quick takeaways that summarize the most important adjustments. 
+    """
+)
+
+# ---------------------------
+# Public API
+# ---------------------------
+def generate_coaching_advice(
+    nl_summary: str,
+    evidence_context_text: str,
+    evidence_json_list: List[Dict[str, Any]],
+    *,
+    model: str = "gpt-5-mini",
+    max_tokens: Optional[int] = None,
+) -> str:
+    """
+    Produce the final coaching response using:
+      - nl_summary: your hand summary from build_nl_summary(...)
+      - evidence_context_text: human-readable context from build_evidence_context(objects, k=3)
+      - evidence_json_list: the parallel machine-readable evidence list (same function returns this)
+    Returns plain text suitable for console output.
+    """
+    llm = ChatOpenAI(model=model, max_tokens=max_tokens)
+
+    user_payload = {
+        "HAND_NL_SUMMARY": nl_summary,                  
+        "EVIDENCE_TEXT": evidence_context_text,         
+        "EVIDENCE_JSON": evidence_json_list,          
+        "INSTRUCTIONS": {
+            "goal": "Provide concise, actionable coaching per street; integrate strongest relevant ideas from EVIDENCE.",
+            "must_use_evidence": True,
+        },
+    }
+
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": json.dumps(user_payload, ensure_ascii=False)},
+    ]
+
+    resp = llm.invoke(messages)
+    # langchain_openai returns an AIMessage with .content
+    return getattr(resp, "content", str(resp))
+
+def evidence_card_from_obj(o) -> dict:
+    """
+    Returns:
+      {
+        "text_block": "...semi-structured evidence card...",
+        "json": { minimal, high-signal json for traceability }
+      }
+    """
+    p = o.properties
+
+    title = p.get("title") or "<untitled>"
+    schema = (p.get("schema_string") or "").strip()
+    line = (p.get("line_compact") or "").strip()
+
+    # Prefer explicit texture_class; fallback to board_texture
+    texture = p.get("texture_class") or p.get("board_texture")
+
+    # Merge tags + improvement_flags and normalize
+    tags = _join_tokens((p.get("tags") or []) + (p.get("improvement_flags") or []))
+
+    # Coaching fields (support old/new)
+    coaching_summary, coaching_actions = _coaching_fields(p)
+
+    # short facets dict (only anchors)
+    facets = _short_facets({
+        "street_focus": p.get("street_focus"),
+        "pot_type": p.get("pot_type"),
+        "texture_class": texture,
+        "spr_bucket": p.get("spr_bucket"),
+        "hero_position": p.get("hero_position"),
+        "villain_position": p.get("villain_position"),
+        "heads_up": p.get("heads_up"),
+        "players_to_flop": p.get("players_to_flop"),
+    })
+
+    block_lines = []
+    block_lines.append(f"[EVIDENCE]")
+    block_lines.append(f"title={title}")
+    if schema:
+        block_lines.append(f"schema={schema}")
+    if line:
+        block_lines.append(f"line={line}")
+    block_lines.append("facets={" + ", ".join(f"{k}: {v}" for k, v in facets.items() if v not in (None, "")) + "}")
+    if texture:
+        block_lines.append(f"texture={str(texture).lower()}")
+    if tags:
+        block_lines.append(f"tags={tags}")
+    if coaching_summary:
+        block_lines.append(f"coaching_summary={coaching_summary}")
+    if coaching_actions:
+        block_lines.append("action_points=" + "; ".join(coaching_actions[:3]))  # keep tight
+
+    text_block = "\n".join(block_lines)
+
+    json_payload = {
+        "title": title,
+        "facets": facets,
+        "schema_string": schema,
+        "line_compact": line,
+        "texture_class": texture,
+        "tags": [t.strip() for t in tags.split(", ")] if tags else [],
+        "coaching_summary": coaching_summary,
+        "coaching_actions": coaching_actions[:5],
+        "score": getattr(o.metadata, "score", None),
+        "uuid": str(o.uuid),
+    }
+
+    return {"text_block": text_block, "json": json_payload}
+
+def build_evidence_context(objects, k) -> tuple[str, list[dict]]:
+    """
+    Compose top-K evidence blocks for the LLM.
+    Returns (context_str, json_list)
+    """
+    cards = [evidence_card_from_obj(o) for o in objects[:k]]
+    context = "\n\n".join(c["text_block"] for c in cards)
+    return context, [c["json"] for c in cards]
+
+# -------------------------------
+# Evidence block builders
+# -------------------------------
+
+def _as_list(x):
+    if not x:
+        return []
+    return x if isinstance(x, list) else [x]
+
+def _join_tokens(tokens):
+    toks = [t for t in _as_list(tokens) if t]
+    # normalize to lowercase and dedupe in stable order
+    seen, out = set(), []
+    for t in toks:
+        t2 = str(t).strip().lower()
+        if t2 and t2 not in seen:
+            seen.add(t2)
+            out.append(t2)
+    return ", ".join(out)
+
+def _short_facets(d):
+    # Only the highest-signal anchors you want the model to key on
+    return {
+        "street_focus": d.get("street_focus"),
+        "pot_type": d.get("pot_type"),
+        "texture_class": d.get("texture_class") or d.get("board_texture"),
+        "spr_bucket": d.get("spr_bucket"),
+        "hero_position": d.get("hero_position"),
+        "villain_position": d.get("villain_position"),
+        "heads_up": d.get("heads_up"),
+        "players_to_flop": d.get("players_to_flop"),
+    }
+
+def _coaching_fields(p):
+    """
+    Support both old and new schema names:
+      - annotated_coaching_description  (old)
+      - coaching_summary                (new)
+      - action_points                   (old)
+      - coaching_actions                (new)
+    """
+    summary = p.get("coaching_summary") or p.get("annotated_coaching_description")
+    actions = p.get("coaching_actions") or p.get("action_points") or []
+    return summary, [a for a in _as_list(actions) if a]
+
+
+if __name__ == "__main__":
+
+    import sys
+    from pathlib import Path
+
+    nl_path = Path("/tmp/nl_summary.txt")
+    ev_path = Path("/tmp/evidence.json")
+
+    if not nl_path.exists() or not ev_path.exists():
+        print("Usage (example): write nl_summary to /tmp/nl_summary.txt and evidence to /tmp/evidence.json, then run:")
+        print("  python llm_coach.py")
+        sys.exit(0)
+
+    nl_summary = nl_path.read_text()
+    ev = json.loads(ev_path.read_text())
+    evidence_context = ev.get("context") or ""
+    evidence_json = ev.get("cards") or []
+
+    out = generate_coaching_advice(nl_summary, evidence_context, evidence_json)
+    print("\n=== Coaching Advice ===\n")
+    print(out)

--- a/utils/rag_builder.py
+++ b/utils/rag_builder.py
@@ -1,0 +1,292 @@
+# utils/rag_builder.py
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from utils.game_flow import POS_9MAX
+from utils.preflop_input import PreflopRecord
+# Street result/record types (import only for typing clarity)
+from utils.flop_input import FlopRecord
+from utils.turn_input import TurnRecord
+from utils.river_input import RiverRecord
+
+# Reuse your rank map for coarse straightness checks
+_RANK_VAL = {r: i for i, r in enumerate("..23456789TJQKA", start=0)}
+
+def build_final_rag_schema(
+    cfg,                                  # HandConfig
+    pre: PreflopRecord,
+    flop_rec: Optional[FlopRecord] = None,
+    flop_feats: Optional[Dict[str, object]] = None,
+    turn_rec: Optional[TurnRecord] = None,
+    river_rec: Optional[RiverRecord] = None,
+    showdown_raw: Optional[str] = None,
+) -> Dict[str, object]:
+    """
+    Combine all streets into a single Weaviate-ready RAG schema object.
+    Safe to call with partial hands (e.g., preflop-only, flop-only, etc.).
+    """
+
+    # ---- Tokens (position-aware, amounts omitted) ----
+    tokens = {"preflop": pre.preflop_tokens}
+    street_tokens: List[str] = [pre.preflop_tokens]
+
+    if flop_rec:
+        tokens["flop"] = flop_rec.tokens
+        street_tokens.append(flop_rec.tokens)
+    if turn_rec:
+        tokens["turn"] = turn_rec.tokens
+        street_tokens.append(turn_rec.tokens)
+    if river_rec:
+        tokens["river"] = river_rec.tokens
+        street_tokens.append(river_rec.tokens)
+
+    line_compact = " || ".join(street_tokens)
+
+    # ---- Boards / Features ----
+    flop_board = getattr(flop_rec, "board", None)
+    turn_card  = getattr(turn_rec, "board", None)
+    river_card = getattr(river_rec, "board", None)
+
+    # Minimal runout features across all visible board cards
+    runout_feats = _analyze_runout(flop_board, turn_card, river_card)
+
+    # If caller didn’t pass flop_feats, derive ultra-light from runout_feats (fallback)
+    if flop_board and not flop_feats:
+        flop_feats = {
+            "flop_board": flop_board,
+            "flush_level": runout_feats.get("flop_flush_level", 1),
+            "paired_level": runout_feats.get("flop_paired_level", 0),
+            "straightness": runout_feats.get("flop_straightness", 0),
+            "high_card_bucket": runout_feats.get("flop_high_card_bucket", "M"),
+            "texture_class": runout_feats.get("flop_texture_class", "dry"),
+        }
+
+    # ---- Facets you’ll filter/rerank on ----
+    positions_flop = _participants_to_flop(pre)
+    facets = {
+        "pot_type": pre.pot_type,
+        "players_to_flop": pre.players_to_flop,
+        "heads_up": pre.players_to_flop == 2,
+        "positions": positions_flop,
+        "stack_depth": getattr(cfg, "stack_depth", None),   # "deep/medium/short" from HandConfig
+        "line_compact": line_compact,
+
+        # Boards
+        "flop_board": flop_board,
+        "turn_card": turn_card,
+        "river_card": river_card,
+
+        # Flop features (preferred – your analyzer)
+        **(flop_feats or {}),
+
+        # Runout features across 4–5 cards
+        "runout_flush_max": runout_feats["runout_flush_max"],           # 1..5 max same suit
+        "flush_by_river": runout_feats["flush_by_river"],               # bool
+        "paired_by_river": runout_feats["paired_by_river"],             # 0 none / 2 pair / 3 trips / 4 quads
+        "straightness_runout": runout_feats["straightness_runout"],     # 0/1/2 (coarse)
+        "runout_texture_class": runout_feats["runout_texture_class"],   # dry/draw-heavy/paired/monotone
+    }
+
+    # ---- Schema + embedding text (concise, texture-focused) ----
+    pre_tokens = tokens["preflop"]
+    flop_tokens = tokens.get("flop")
+    turn_tokens = tokens.get("turn")
+    river_tokens = tokens.get("river")
+
+    schema_string = (
+        f"{_safe_schema_tokens(cfg)} "
+        f"| preflop={pre_tokens}"
+        + (f" | flop={flop_tokens}" if flop_tokens else "")
+        + (f" | turn={turn_tokens}" if turn_tokens else "")
+        + (f" | river={river_tokens}" if river_tokens else "")
+    )
+
+    # Build an NL embedding text that avoids exact ranks/suits; focuses on structure/texture
+    desc_chunks = [
+        _safe_schema_tokens(cfg),
+        f"Preflop: {pre_tokens}."
+    ]
+    if flop_tokens:
+        desc_chunks.append(f"Flop: {flop_tokens}. Board is {facets.get('texture_class', 'unknown')} "
+                           f"(flush={facets.get('flush_level')}, paired={facets.get('paired_level')}, "
+                           f"straightness={facets.get('straightness')}).")
+    if turn_tokens:
+        desc_chunks.append(f"Turn: {turn_tokens}.")
+    if river_tokens:
+        desc_chunks.append(f"River: {river_tokens}. Runout is {facets.get('runout_texture_class')} "
+                           f"(flush_by_river={facets.get('flush_by_river')}, "
+                           f"paired_by_river={facets.get('paired_by_river')}, "
+                           f"straightness={facets.get('straightness_runout')}).")
+
+    embedding_text = " ".join(desc_chunks)
+
+    # ---- Hard/soft retrieval controls (tune as you go) ----
+    hard_filters = {"pot_type": pre.pot_type}
+    soft_signals = {
+        "texture_class": facets.get("texture_class"),
+        "runout_texture_class": facets.get("runout_texture_class"),
+        "heads_up": facets["heads_up"],
+        "stack_depth": facets.get("stack_depth"),
+    }
+
+    # Do not surface results in embeddings; keep raw showdown text out of embedding_text
+    payload = {
+        "title": "User-entered hand",
+        "schema_string": schema_string,
+        "embedding_text": embedding_text,
+        "facets": facets,
+        "tokens": tokens,
+        "hard_filters": hard_filters,
+        "soft_signals": soft_signals,
+    }
+    if showdown_raw:
+        payload["showdown_raw"] = showdown_raw  # keep but don’t embed
+
+    return payload
+
+
+# --------------------------
+# Helpers
+# --------------------------
+
+def _safe_schema_tokens(cfg) -> str:
+    """
+    Use HandConfig.schema_tokens() if available, otherwise fall back to a compact line.
+    Avoid crashing if schema_tokens has been customized.
+    """
+    try:
+        return cfg.schema_tokens()
+    except Exception:
+        # Minimal fallback
+        s = getattr(cfg, "stakes_bb", None)
+        pos = getattr(cfg, "hero_position", "?")
+        hand = getattr(cfg, "hero_hand", "??")
+        return f"stakes=? table=? pos={pos} hero={hand}"
+
+def _participants_to_flop(pre: PreflopRecord) -> List[str]:
+    """
+    Seats whose *final* preflop state is call/raise (not fold), in table order.
+    Mirrors your participants_to_flop helper.
+    """
+    final = {pre.opener: "raise"}
+    for a in pre.trail_actions:
+        final[a.position] = a.action
+    involved = [p for p, act in final.items() if act in ("call", "raise")]
+    return [p for p in POS_9MAX if p in involved]
+
+def _analyze_runout(
+    flop_board: Optional[str],
+    turn_card: Optional[str],
+    river_card: Optional[str],
+) -> Dict[str, object]:
+    """
+    Coarse runout features across the visible board (3–5 cards):
+    - max suit count (-> flush_by_river)
+    - paired strength across ranks
+    - straightness (coarse) across 4–5 cards
+    Also emits *flop-only* features (for fallback when no dedicated flop analyzer is passed).
+    """
+    # Helper to parse 2-char cards
+    def _split_cards(s: str) -> List[str]:
+        return [s[i:i+2] for i in range(0, len(s), 2)] if s else []
+
+    flop_cards = _split_cards(flop_board)        # len 3 or []
+    all_cards = flop_cards + ([turn_card] if turn_card else []) + ([river_card] if river_card else [])
+
+    # ---- Flop-only (fallbacks) ----
+    flop_ranks = [c[0] for c in flop_cards]
+    flop_suits = [c[1] for c in flop_cards]
+    flop_suit_counts = {s: flop_suits.count(s) for s in set(flop_suits)} or {"x": 1}
+    flop_flush_level = max(flop_suit_counts.values())
+    flop_rank_counts = {r: flop_ranks.count(r) for r in set(flop_ranks)} or {}
+    flop_paired_level = 0 if not flop_rank_counts else max(flop_rank_counts.values())
+    flop_paired_level = 0 if flop_paired_level == 1 else flop_paired_level
+    flop_vals = sorted({_RANK_VAL[r] for r in flop_ranks}) if flop_ranks else []
+    straightness_flop = _coarse_straightness(vals=flop_vals)
+    flop_hi = max(flop_vals) if flop_vals else _RANK_VAL["T"]  # bias medium/high if unknown
+    flop_high_bucket = "H" if flop_hi >= _RANK_VAL["Q"] else ("M" if flop_hi >= _RANK_VAL["9"] else "L")
+    if flop_flush_level == 3:
+        flop_tex = "monotone"
+    elif flop_paired_level >= 2:
+        flop_tex = "paired"
+    elif straightness_flop >= 1:
+        flop_tex = "draw-heavy"
+    else:
+        flop_tex = "dry"
+
+    # ---- Runout features (4–5 cards) ----
+    ranks = [c[0] for c in all_cards]
+    suits = [c[1] for c in all_cards]
+
+    suit_counts = {s: suits.count(s) for s in set(suits)} or {"x": 1}
+    runout_flush_max = max(suit_counts.values())
+
+    rank_counts = {r: ranks.count(r) for r in set(ranks)} or {}
+    # paired_by_river: 0 none / 2 pair / 3 trips / 4 quads (values echo your earlier style)
+    paired_raw = 0 if not rank_counts else max(rank_counts.values())
+    if paired_raw <= 1:
+        paired_by_river = 0
+    elif paired_raw == 2:
+        paired_by_river = 2
+    elif paired_raw == 3:
+        paired_by_river = 3
+    else:
+        paired_by_river = 4
+
+    vals = sorted({_RANK_VAL[r] for r in ranks}) if ranks else []
+    straightness_runout = _coarse_straightness(vals=vals, allow_len=len(all_cards))
+
+    if runout_flush_max >= 5:
+        runout_tex = "monotone"
+    elif paired_by_river >= 2:
+        runout_tex = "paired"
+    elif straightness_runout >= 1:
+        runout_tex = "draw-heavy"
+    else:
+        runout_tex = "dry"
+
+    return {
+        # flop fallback
+        "flop_flush_level": flop_flush_level,
+        "flop_paired_level": 0 if flop_paired_level == 0 else (1 if flop_paired_level == 2 else 3),
+        "flop_straightness": straightness_flop,
+        "flop_high_card_bucket": flop_high_bucket,
+        "flop_texture_class": flop_tex,
+
+        # runout
+        "runout_flush_max": runout_flush_max,
+        "flush_by_river": runout_flush_max >= 5,
+        "paired_by_river": paired_by_river,
+        "straightness_runout": straightness_runout,
+        "runout_texture_class": runout_tex,
+    }
+
+def _coarse_straightness(vals: List[int], allow_len: int = 3) -> int:
+    """
+    Coarse straightness 0/1/2:
+    - 2: there exists a tight window (span <= 3) covering min(allow_len, 4) or more unique ranks
+    - 1: there exists a looser window (span <= 5) with at least 4 unique ranks
+    - 0: otherwise
+    Treat A as both high and potential wheel (A=14 and also consider 1).
+    """
+    if not vals:
+        return 0
+    uniq = sorted(set(vals))
+    # also consider wheel by mapping A->1
+    uniq_wheel = sorted({1 if v == _RANK_VAL["A"] else v for v in uniq})
+
+    def window_score(arr: List[int], need: int) -> int:
+        n = len(arr)
+        if n < need:
+            return 0
+        for i in range(n - need + 1):
+            span = arr[i + need - 1] - arr[i]
+            if need >= 4 and span <= 3:
+                return 2
+            if need >= 4 and span <= 5:
+                return 1
+        return 0
+
+    need = 4 if allow_len >= 4 else min(allow_len, 3)
+    return max(window_score(uniq, need), window_score(uniq_wheel, need))

--- a/utils/rag_pipeline.py
+++ b/utils/rag_pipeline.py
@@ -81,14 +81,6 @@ def build_final_rag_schema(
         "straightness_runout": runout["straightness_runout"],
         "runout_texture_class": runout["runout_texture_class"],
     }
-
-    # schema_string = (
-    #     f"{_safe_schema_tokens(cfg)} "
-    #     f"| preflop={tokens['preflop']}"
-    #     + (f" | flop={tokens['flop']}" if 'flop' in tokens else "")
-    #     + (f" | turn={tokens['turn']}" if 'turn' in tokens else "")
-    #     + (f" | river={tokens['river']}" if 'river' in tokens else "")
-    # )
     schema_string = _safe_schema_tokens(cfg)
 
     pieces = [
@@ -139,303 +131,248 @@ def build_final_rag_schema(
 # 2) LLM enrichment: map user doc -> corpus facet schema
 # --------------------------
 
-ALLOWED_TOP_KEYS = {
-    "title", "schema_string", "embedding_text",
-    "facets", "hard_filters", "soft_signals",
-    "rule_features", "tags"
-}
 
 def enrich_user_hand_with_llm(llm, raw_doc: dict, cfg) -> dict:
     """
-    Produce a RAG-ready JSON (exact shape from your prompt).
-    - Uses LLM to normalize & infer missing facets.
-    - Merges in deterministic features from raw_doc.
-    - Returns ONLY the keys defined by the prompt (no extras).
+    Produce a RAG-ready JSON by calling an LLM with a compact system prompt
+    + structured output (JSON Schema with enums). No post normalizer/validator here.
     """
 
-    #REMOVED: Do not mention specific hole cards or suits when describing the hand unless the inclusion of specific cards will help convey the concept more evidently. Focus on the spot, not the result.
-    # ----- 1) Your exact instructions as system prompt -----
-    system = (
-        """
-        You are a Poker strategy assistant that converts short, summarized hand review segments from a hand into a RAG‑ready JSON. Output must be valid JSON only. Your job is to:
-        Produce a compact, normalized schema string that captures the strategic spot.
-        Emit facets for filtering and reranking, using the controlled vocabularies below.
-        Generate a clean embedding_text that combines the schema string and the annotated coaching description.
-        Add rule_features for a lightweight, poker‑aware reranker.
-        Separate hard_filters from soft_signals so the retriever can do graduated backoff.
-        CRITICAL (internal reasoning only): You are given the hero’s exact hand and the board cards in `private_hints`.
-        Use them solely to infer `hero_hand_class` and `blocker_pattern`. Think step-by-step **internally**; do NOT reveal your reasoning or the exact cards. Output VALID JSON only.
+    # -----------------------------
+    # 0) Build inputs for the call
+    # -----------------------------
 
-        Street focus
-        - Classify on ONE street: river if present, else turn, else flop, unless a specific street is explicitly called out.
-
-        Internal decision cascade (stop at the first match on the chosen street)
-        Assemble the best 5-card hand from hero’s 2 cards + the board.
-        1) Straight-flush (royal flush is a special case of straight-flush) – five in sequence, all same suit. Label as `"straight-flush"`.
-        2) Quads – four of a kind.
-        3) Full house – any three-of-a-kind + any pair.
-        4) Flush – five to the same suit.
-        5) Straight – five in sequence; allow A-5 wheel.
-        6) Set – pocket pair matching exactly one board rank (not trips from board alone).
-        7) Two-pair – two distinct ranks paired (hole+board or board+board+hole).
-        8) Overpair – pocket pair strictly higher than **all** board ranks.
-        9) Underpair – pocket pair lower than the **highest** board rank and not present on the board.
-        10) Top-pair – one hole equals the highest distinct board rank.
-        11) Second-pair – one hole equals the second-highest distinct board rank.
-        12) Weak-pair – one hole equals a lower distinct board rank (3rd+).
-        13) Draw – ONLY if none above applies (e.g., 4-flush, OESD, gutshot)(MUST BE BEFORE THE RIVER).
-        14) Air – none of the above.
-
-        Disambiguation / fail-safes
-        - Never assign **overpair** unless it strictly meets the definition. If unsure between overpair and under/second/weak-pair, choose the latter.
-        - If both a made hand and a draw exist, choose the higher category from the cascade.
-        - `"bluff-catcher"` is for river-only, marginal one-pair spots in clearly polar situations; otherwise use the structural class.
-
-        Blockers
-        - Monotone or 4-flush runouts + hero holds the Ace of that suit → `blocker_pattern="flush_blocker"`.
-        - Highly connected/broadway boards with hero removing common straights → `blocker_pattern="broadway_blocker"`.
-        - Hero blocks the nut straight with key ranks → `blocker_pattern="straight_blocker"`.
-        - Else, null.
-
-        Privacy
-        - Do not echo ranks/suits in the output—only derived labels (e.g., `"overpair"`, `"second-pair"`, `"straight-flush"`, `"flush_blocker"`).
-
-        Vocabulary alignment
-        - `hero_hand_class` must be one of:
-        ["air","draw","weak-pair","second-pair","top-pair","overpair","underpair",
-        "two-pair","set","straight","flush","full house","quads","straight-flush","bluff-catcher"].
-
-        Controlled vocabularies
-        pot_type: single-raised, 3-bet, 4-bet, limped, multiway, heads-up,straddle
-        positions (primary hero pos; villain optional): UTG, EP, MP, LJ, HJ, CO, BTN, SB, BB, straddle, BvB
-        street_events tokens (use any that apply, order by time):
-        open, call, 3bet, 4bet, c-bet, delayed-cbet, donk, check-raise, float, probe, barrel, overbet, jam, min-raise, x, bet-small, bet-mid, bet-big
-        board_texture: dry, two-tone, monotone, paired, paired+, draw-heavy, high-connect, low-connect, coordinated, rainbow
-        hero_hand_class: overpair, underpair, top-pair, second-pair, weak-pair, set, two-pair, trips, straight, flush, full house, quads, combo draw, flush draw, straight draw, gutshot, overcards, air, bluff-catcher
-        stack_dynamics: short, medium, deep, plus SPR<1, SPR~2, SPR~3-5, SPR>5
-        strategic_themes: thin value, exploit, GTO deviation, capped range attack, missed value, bluff catcher, indifferent, sizing tell, induce, deny equity, range advantage, story inconsistency, leveling,nit-villain, loose-villain,strong player, weak player, etc.
-        Derived board features
-        Compute coarse, integer features from the description. If unknown, infer from context or set null.
-        flush_level: 0–4 where 0 none, 3 three to a suit, 4 four to a suit or completed flush environment.
-        paired_level: 0 none, 1 one pair on board, 2 trips/paired+, 3 double-paired+.
-        straightness: 0 low, 1 some connectivity, 2 high connectivity.
-        high_card_bucket: H (A/K present), M (Q/J/T), L (<=9 focus).
-        texture_class: one of board_texture above that best summarizes the runout.
-        If the transcript indicates blockers, set blocker_pattern such as flush_blocker, straight_blocker, ace_blocker, broadway_blocker.
-        Output shape
-        Return one JSON object per video with exactly these keys:
-        json
-        Copy
-        {
-        "title": "string",
-        "schema_string": "single line, normalized tokens (from inputted schema_string)",
-        "embedding_text": "schema_string + hand recap (from inputted embedding_text)",
+    facets_in = raw_doc.get("facets", {}) or {}
+    derived_fields = {
         "facets": {
-            "pot_type": "single-raised|3-bet|4-bet|limped|multiway|heads-up",
-            "hero_position": "UTG|EP|...|BB|BvB",
-            "villain_position": "optional",
-            "heads_up": true,
-            "street_focus": "flop|turn|river|all",
-            "board_texture": "see vocab",
-            "flush_level": 0,
-            "paired_level": 0,
-            "straightness": 0,
-            "high_card_bucket": "H|M|L",
-            "texture_class": "see vocab",
-            "hero_hand_class": "see vocab",
-            "blocker_pattern": "string or null",
-            "spr_bucket": "SPR<1|SPR~2|SPR~3-5|SPR>5",
-            "stack_depth": "short|medium|deep",
-            "line_compact": "tokenized street_events, e.g., 'open call | c-bet call | barrel jam'",
-            "positions": ["hero", "villain", "others if relevant"]
-        },
-        "hard_filters": {
-            "pot_type": "value",
-            "street_focus": "value or null if not specific"
-        },
-        "soft_signals": {
-            "texture_class": "value",
-            "hero_hand_class": "value",
-            "spr_bucket": "value",
-            "line_tokens": ["c-bet","check-raise","barrel","jam"],
-            "heads_up": true
-        },
-        "rule_features": {
-            "board": { "texture_class": "value", "flush_level": 0, "paired_level": 0, "straightness": 0, "high_card_bucket": "H|M|L" },
-            "hero": { "hand_class": "value", "blocker_pattern": "value or null" },
-            "context": { "spr_bucket": "value", "position_primary": "hero_position", "line_compact": "same as facets.line_compact" }
-        },
-        "tags": ["comma style tags for UI and quick filters"],
+            "positions":      facets_in.get("positions"),
+            "line_compact":   facets_in.get("line_compact"),
+            "pot_type":       facets_in.get("pot_type"),
+            "heads_up":       facets_in.get("heads_up"),
+            "spr_bucket":     facets_in.get("spr_bucket"),
+            "stack_depth":    facets_in.get("stack_depth"),
+            "texture_class":  facets_in.get("texture_class"),
+            "flush_level":    facets_in.get("flush_level"),
+            "paired_level":   facets_in.get("paired_level"),
+            "straightness":   facets_in.get("straightness"),
+            "high_card_bucket": facets_in.get("high_card_bucket"),
+            "hero_position":  facets_in.get("hero_position"),
         }
+    }
 
-        Construction rules
-        schema_string is short and machine‑friendly. Example pattern:
-        pot=3-bet HU pos=BTN_vs_SB spr=~2 hero=overpair board=paired dry line=c-bet-call | barrel | river overbet
-        embedding_text = schema_string + hand summary from the perspective of the hero (include hero's actions, villains actions and board textures)
-        Prefer inference: if the board is monotone and the user contains the Ace of the suit on the board, set board_texture=monotone, flush_level>=3, blocker_pattern=flush_blocker, hero_hand_class=bluff-catcher if consistent. Do your best to infer these fields.
-        If the street focus is clearly about one decision point, set street_focus to that street, else all.
-        If info is missing, keep fields but set to "None" and avoid guessing wildly.
-        """
+    private_hints = {
+        "hero_hand":  getattr(cfg, "hero_hand", None),
+        "flop_board": facets_in.get("flop_board"),
+        "turn_card":  facets_in.get("turn_card"),
+        "river_card": facets_in.get("river_card"),
+    }
+
+    raw_min = {
+        "schema_string":  raw_doc.get("schema_string", ""),
+        "embedding_text": raw_doc.get("embedding_text", ""),
+        "facets":         facets_in,
+        "tokens":         raw_doc.get("tokens", {}),
+        "title":          raw_doc.get("title", "User-entered hand"),
+    }
+
+    # ---------------------------------
+    # 1) Compact system rules (prompt)
+    # ---------------------------------
+    system = (
+        "You are a poker strategy enricher. Output JSON only that conforms to the provided JSON Schema (PokerRAGEntry).\n"
+        "INPUTS in user message:\n"
+        "- DERIVED_FIELDS: objective truths computed upstream; copy verbatim and do NOT change.\n"
+        "- RAW_JSON: canonical user hand context.\n"
+        "- PRIVATE_HINTS: exact hole cards and board (for inference only; never reveal).\n\n"
+        "TASK: Produce schema_string, facets, hard_filters vs soft_signals, tags, and embedding_text.\n\n"
+        "GLOBAL RULES:\n"
+        "- JSON only; no prose outside fields. If unknown, set null.\n"
+        "- Never reveal exact cards/suits. Use concepts only.\n"
+        "- Use PRIVATE_HINTS only to infer hero_hand_class and blocker_pattern.\n"
+        "- Choose one street_focus (river > turn > flop unless the input says otherwise).\n"
+        "- Don't duplicate the betting line: keep canonical line in facets.line_compact; embedding_text may include it once.\n"
+        "- Keep values within schema enums; do not invent new tokens.\n\n"
+        "HAND CLASS (on chosen street) priority:\n"
+        "quads/full house/flush/straight > set > two-pair > overpair/underpair > top/second/weak-pair > draw > air.\n"
+        "Definitions (strict): overpair = pocket pair higher than all board ranks; underpair = lower than the highest board rank and not on board; "
+        "top/second/weak-pair = hole equals 1st/2nd/3rd+ highest distinct board rank; set = pocket pair matches a single board rank. "
+        "If unsure between over/underpair, prefer underpair unless the overpair condition is strictly met.\n\n"
+        "CONSTRUCTION:\n"
+        "- schema_string: short, normalized tokens (pot/formation/pos/SPR/hero/board). Avoid per-street prose.\n"
+        "- embedding_text: schema_string + one 'line=' from facets.line_compact + brief board features; no per-street narratives.\n"
+        "- hard_filters: minimally pot_type and street_focus when known.\n"
+        "- soft_signals: select 3–5 high-signal descriptors from the allowed improvement_flags list below; dedupe; also append to tags.\n\n"
+        "ALLOWED improvement_flags (use these exact tokens or come up with your own flags (but don't deviate too far from the original intent)):\n"
+        "A) dynamic_board, static_board, wet_board, dry_board, coordinated_high_connect, low_connect, monotone_pressure, two_tone_pressure, paired_board, paired_plus\n"
+        "B) turn_completes_flush, turn_completes_straight, turn_pairs_board, straightening_turn, river_pairs_top, river_pairs_low, four_flush_river, backdoor_flush_river, backdoor_straight_river, scare_card_river, brick_river\n"
+        "C) range_advantage_hero, nut_advantage_hero, range_advantage_villain, nut_advantage_villain, hero_IP, hero_OOP, multiway_pressure, blind_vs_blind\n"
+        "D) turned_top_pair_value, underpair_showdown_bound, overpair_marginal_board, bluff_catcher_river, flush_blocker_pressure, straight_blocker_pressure, broadway_blocker_pressure\n"
+        "E) small_cbet_range_node, polar_turn_barrel, delayed_cbet_viable, check_raise_dense, donk_represented, overbet_polar_node, thin_value_ok, cap_attack_spot, induce_vs_polar_line, minraise_strength_tell\n"
+        "F) pool_low_bluff, pool_calls_wide, strong_player_present, weak_player_target, sticky_pool, nit_villain\n"
+        "G) price_to_continue_good, fold_equity_low, deny_equity_priority, realization_penalty_OOP\n\n"
+        "VALIDATION:\n"
+        "- Do not alter DERIVED_FIELDS. Keep enums within schema vocab. If uncertain, set null."
     )
 
-
-    facets = raw_doc.get("facets", {})
-    fewshots = [
-        {
-            "input": {
-                "schema_string": "pot=3-bet pos=BB spr=~3 board=draw-heavy",
-                "embedding_text": "Preflop 3-bet, BB vs BTN. Flop is Q-high and connected. River checks through."
-            },
-            "private_hints": {
-                "hero_hand": "JhJd", "flop_board": "Qs7c3h", "turn_card": "2d", "river_card": "9s"
-            },
-            "expect": {
-                "facets.hero_hand_class": "underpair"
-            }
-        },
-        {
-            "input": {
-                "schema_string": "pot=single-raised pos=HJ spr=>5 board=dry",
-                "embedding_text": "Single-raised, HJ vs BB. Flop is T-high, dry."
-            },
-            "private_hints": {
-                "hero_hand": "JdJc", "flop_board": "Td4s2c", "turn_card": "7h", "river_card": "Qh"
-            },
-            "expect": {
-                "facets.hero_hand_class": "overpair"
-            }
-        },
-        {
-            "input": {"schema_string": "pot=single-raised pos=CO board=coordinated"},
-            "private_hints": {"hero_hand": "Qs9s", "flop_board": "KhQd7c", "turn_card": "2h", "river_card": "2c"},
-            "expect": {"facets.hero_hand_class": "second-pair"}
-        },
-        {
-            "input": {"schema_string": "pot=single-raised pos=BTN board=monotone"},
-            "private_hints": {"hero_hand": "AdKc", "flop_board": "5d9dQd", "turn_card": "2s", "river_card": "2c"},
-            "expect": {"facets.blocker_pattern": "flush_blocker"}
-        },
-        {
-            "input": {"schema_string": "pot=single-raised pos=BTN board=monotone"},
-            "private_hints": {"hero_hand": "Ah4h", "flop_board": "QhJh9h", "turn_card": "8d", "river_card": "2c"},
-            "expect": {"facets.blocker_pattern": "flush_blocker", "facets.hero_hand_class": "flush"}
-        },
-        {
-            "input": {"schema_string": "pot=single-raised pos=BTN board=monotone"},
-            "private_hints": {"hero_hand": "7h6d", "flop_board": "5h3d9s"},
-            "expect": {"facets.blocker_pattern": "flush_blocker", "facets.hero_hand_class": "GS"}
-        },
+    # ------------------------------------
+    # 2) JSON Schema with key enums (SO)
+    # ------------------------------------
+    POT_TYPES = ["limped", "single-raised", "3-bet", "4-bet", "5-bet", "6-bet", "7-bet", ">8-bet", None]
+    POSITIONS = ["UTG", "EP", "MP", "LJ", "HJ", "CO", "BTN", "SB", "BB", "BvB", "straddle", None]
+    TEXTURES  = ["dry", "paired", "monotone", "two-tone", "draw-heavy", "high-connect", "low-connect", "coordinated", "rainbow", None]
+    SPR_BUCKETS  = ["SPR<1", "SPR~2", "SPR~3-5", "SPR>5", None]
+    STACK_DEPTHS = ["short", "medium", "deep", None]
+    HIGH_BUCKETS = ["H", "M", "L", None]
+    STREET_FOCUS = ["flop", "turn", "river", "all", None]
+    HERO_HAND_CLASSES = [
+        "air","draw","weak-pair","second-pair","top-pair","overpair","underpair",
+        "two-pair","set","straight","flush","full house","quads","straight-flush","bluff-catcher", None
     ]
 
-    user_payload = {
-        "input": {
-            "schema_string": raw_doc.get("schema_string", ""),
-            "embedding_text": raw_doc.get("embedding_text", ""),
-            "facets": facets,                    # includes texture metrics you already computed
-            "tokens": raw_doc.get("tokens", {}), # preflop/flop/turn/river tokens if present
-        },
-        "private_hints": {
-            "hero_hand": getattr(cfg, "hero_hand", None),         # e.g., "QhJh"
-            "flop_board": facets.get("flop_board"),               # e.g., "9dQd2d"
-            "turn_card":  facets.get("turn_card"),                # e.g., "Tc"
-            "river_card": facets.get("river_card"),               # e.g., "9h"
-        },
-        "few_shots": fewshots,
-    }
-    # Constrain output with a JSON schema (enumerations keep it on-rails)
+    # exact improvement_flags list (verbatim)
+    IMPROVEMENT_FLAGS = [
+        # A) Board/texture nuance
+        "dynamic_board","static_board","wet_board","dry_board","coordinated_high_connect","low_connect",
+        "monotone_pressure","two_tone_pressure","paired_board","paired_plus",
+        # B) Runout events
+        "turn_completes_flush","turn_completes_straight","turn_pairs_board","straightening_turn",
+        "river_pairs_top","river_pairs_low","four_flush_river","backdoor_flush_river",
+        "backdoor_straight_river","scare_card_river","brick_river",
+        # C) Advantage / formation
+        "range_advantage_hero","nut_advantage_hero","range_advantage_villain","nut_advantage_villain",
+        "hero_IP","hero_OOP","multiway_pressure","blind_vs_blind",
+        # D) Hand-state & blockers
+        "turned_top_pair_value","underpair_showdown_bound","overpair_marginal_board","bluff_catcher_river",
+        "flush_blocker_pressure","straight_blocker_pressure","broadway_blocker_pressure",
+        # E) Line & sizing semantics
+        "small_cbet_range_node","polar_turn_barrel","delayed_cbet_viable","check_raise_dense",
+        "donk_represented","overbet_polar_node","thin_value_ok","cap_attack_spot",
+        "induce_vs_polar_line","minraise_strength_tell",
+        # F) Pool/opp tendencies
+        "pool_low_bluff","pool_calls_wide","strong_player_present","weak_player_target","sticky_pool","nit_villain",
+        # G) Pricing / equity realization
+        "price_to_continue_good","fold_equity_low","deny_equity_priority","realization_penalty_OOP"
+    ]
+
     response_schema = {
         "type": "json_schema",
         "json_schema": {
             "name": "PokerRAGEntry",
             "schema": {
                 "type": "object",
+                "additionalProperties": False,
                 "properties": {
                     "title": {"type": "string"},
                     "schema_string": {"type": "string"},
                     "embedding_text": {"type": "string"},
                     "facets": {
                         "type": "object",
+                        "additionalProperties": False,
                         "properties": {
-                            "pot_type": {"type": ["string", "null"]},
-                            "hero_position": {"type": ["string", "null"]},
-                            "villain_position": {"type": ["string", "null"]},
-                            "heads_up": {"type": ["boolean", "null"]},
-                            "street_focus": {"type": ["string", "null"], "enum": ["flop","turn","river","all", None]},
-                            "board_texture": {"type": ["string", "null"]},
-                            "flush_level": {"type": ["integer", "null"]},
-                            "paired_level": {"type": ["integer", "null"]},
-                            "straightness": {"type": ["integer", "null"]},
-                            "high_card_bucket": {"type": ["string", "null"], "enum": ["H","M","L", None]},
-                            "texture_class": {"type": ["string", "null"]},
-                            "hero_hand_class": {
-                                "type": ["string", "null"],
-                                "enum": [
-                                    "air","draw","weak-pair","second-pair","top-pair",
-                                    "overpair","underpair","two-pair","set","straight",
-                                    "flush","full house","quads","bluff-catcher", None
-                                ]
-                            },
+                            "pot_type":        {"type": ["string", "null"], "enum": POT_TYPES},
+                            "hero_position":   {"type": ["string", "null"], "enum": POSITIONS},
+                            "villain_position":{"type": ["string", "null"], "enum": POSITIONS},
+                            "heads_up":        {"type": ["boolean", "null"]},
+                            "players_to_flop": {"type": ["integer", "null"]},
+                            "street_focus":    {"type": ["string", "null"], "enum": STREET_FOCUS},
+                            "board_texture":   {"type": ["string", "null"], "enum": TEXTURES},
+                            "flush_level":     {"type": ["integer", "null"]},
+                            "paired_level":    {"type": ["integer", "null"]},
+                            "straightness":    {"type": ["integer", "null"]},
+                            "high_card_bucket":{"type": ["string", "null"], "enum": HIGH_BUCKETS},
+                            "texture_class":   {"type": ["string", "null"], "enum": TEXTURES},
+                            "hero_hand_class": {"type": ["string", "null"], "enum": HERO_HAND_CLASSES},
                             "blocker_pattern": {"type": ["string", "null"]},
-                            "spr_bucket": {"type": ["string", "null"]},
-                            "stack_depth": {"type": ["string", "null"], "enum": ["short","medium","deep", None]},
-                            "line_compact": {"type": ["string", "null"]},
-                            "positions": {"type": "array", "items": {"type": "string"}}
+                            "spr_bucket":      {"type": ["string", "null"], "enum": SPR_BUCKETS},
+                            "stack_depth":     {"type": ["string", "null"], "enum": STACK_DEPTHS},
+                            "line_compact":    {"type": ["string", "null"]},
+                            "positions":       {"type": "array", "items": {"type": "string"}}
                         },
                         "required": ["positions", "line_compact"]
                     },
                     "hard_filters": {"type": "object"},
-                    "soft_signals": {"type": "object"},
-                    "rule_features": {"type": "object"},
+                    "soft_signals": {
+                        "type": "object",
+                        "additionalProperties": True,
+                        "properties": {
+                            "texture_class":  {"type": ["string","null"], "enum": TEXTURES},
+                            "hero_hand_class":{"type": ["string","null"], "enum": HERO_HAND_CLASSES},
+                            "spr_bucket":     {"type": ["string","null"], "enum": SPR_BUCKETS},
+                            "line_tokens":    {"type": "array", "items": {"type": "string"}},
+                            "heads_up":       {"type": ["boolean","null"]},
+                            # exact allowed improvement flags:
+                            "improvement_flags": {"type": "array", "items": {"type": "string", "enum": IMPROVEMENT_FLAGS}}
+                        }
+                    },
                     "tags": {"type": "array", "items": {"type": "string"}}
                 },
-                "required": ["title","schema_string","embedding_text","facets","hard_filters","soft_signals","rule_features","tags"],
-                "additionalProperties": False
+                "required": [
+                    "title","schema_string","embedding_text","facets",
+                    "hard_filters","soft_signals","tags"
+                ]
             }
         }
     }
 
+    # -----------------------------
+    # 3) Build user message payload
+    # -----------------------------
+    user_payload = {
+        "DERIVED_FIELDS": derived_fields,
+        "RAW_JSON": raw_min,
+        "PRIVATE_HINTS": private_hints,
+    }
+
+    # -----------------------------
+    # 4) Invoke LLM (structured out)
+    # -----------------------------
     resp = llm.invoke(
         [
             {"role": "system", "content": system},
             {"role": "user", "content": json.dumps(user_payload)}
         ],
         response_format=response_schema,
-        #temperature=0,
     )
 
-    # Parse & light normalization (no deterministic overrides)
+    # -----------------------------
+    # 5) Parse & light backfill only
+    # -----------------------------
     content = getattr(resp, "content", resp)
     try:
-        enriched = json.loads(content) if isinstance(content, str) else json.loads(content or "{}")
+        enriched = json.loads(content) if isinstance(content, str) else (content if isinstance(content, dict) else {})
     except Exception:
         enriched = {}
 
-    enriched = {k: v for k, v in enriched.items() if k in ALLOWED_TOP_KEYS}
+    # Ensure top-level keys exist
     enriched.setdefault("title", raw_doc.get("title", "User-entered hand"))
     enriched.setdefault("schema_string", raw_doc.get("schema_string", ""))
     enriched.setdefault("embedding_text", raw_doc.get("embedding_text", ""))
     enriched.setdefault("facets", {})
     enriched.setdefault("hard_filters", {})
     enriched.setdefault("soft_signals", {})
-    enriched.setdefault("rule_features", {})
+    #enriched.setdefault("rule_features", {})
     enriched.setdefault("tags", [])
 
-    # (Optional but harmless) backfill neutral fields from raw_doc if missing
-    f = enriched["facets"]
-    for k in ["positions","line_compact","pot_type","stack_depth","texture_class",
-              "board_texture","flush_level","paired_level","straightness","high_card_bucket",
-              "flop_board","turn_card","river_card"]:
+    # Backfill obvious facet fields from raw if model left them null
+    f = enriched["facets"] or {}
+    for k in [
+        "positions","line_compact","pot_type","stack_depth","texture_class","board_texture",
+        "flush_level","paired_level","straightness","high_card_bucket","heads_up",
+        "flop_board","turn_card","river_card","spr_bucket","hero_position","villain_position"
+    ]:
         if f.get(k) in (None, "", [], {}):
-            val = facets.get(k)
+            val = facets_in.get(k)
             if val is not None:
                 f[k] = val
+    enriched["facets"] = f
 
-    # Hard filters: avoid nulls (this prevents your previous GRPC “unknown value type <nil>” error)
-    hf = enriched["hard_filters"]
+    # Minimal hard_filters fill (no nulls)
+    hf = enriched["hard_filters"] or {}
     if f.get("pot_type"):
         hf["pot_type"] = f["pot_type"]
     if f.get("street_focus") in ("flop","turn","river"):
         hf["street_focus"] = f["street_focus"]
+    enriched["hard_filters"] = hf
 
     return enriched
 


### PR DESCRIPTION
Completed RAG pipeline:

Pipeline:
1. User inputs a NL Texas Hold 'Em hand (hand config, preflop, flop, turn, river information)
2. Hand gets converted to a standardized RAG schema
3. RAG schema uses an additional LLM call to enrich the schema with additional essential fields (see response_schema in rag_pipeline.py). This will output an enriched JSON object filled with specific hand details.
4. A natural language summary of the hand is generated
5. The weaviate client is connected to the server and we use hybrid query (with the enriched JSON as the vector query) in the weaviate vector database to search for the most semantically similar hands) to retrieve the most relevant hands and the coaching tips associated with them.
6. One final LLM call is used to construct the street-by-street coaching advice for the user's inputted hand. (nl_summary, evidence context, evidence_json are used as context for the LLM call). Return the coaching to the user.

The theory is that we hard query based on specifc tags along with a normal querying with the hand embedding. I found that these LLM-produced tags and RAG schema is the most accurate for the hybrid querying. Simply using normal querying or hard filter querying tends to retrieve unrelated hands and will produce hallucinations for the LLM.